### PR TITLE
better filling output of WHOIS response

### DIFF
--- a/01/whoishere/whoishere.sh
+++ b/01/whoishere/whoishere.sh
@@ -103,5 +103,10 @@ IPS=$(echo "$IPS" | tail -n "$NUMLINES" | grep -oP '(\d+\.){3}\d+')
 echo $'\nWHOIS:'
 for ip in $IPS
 do
-  echo $ip $'\t' $(whois $ip | grep  -i "^$FIELD")
+  if [ "$FIELD"="organization" ]
+  then 
+    echo $ip $'\t' $(whois $ip | awk -F':' '/^OrgName|^org-name|^role|^person/ {print $2}' | tr -s ' ' | uniq)
+  else
+    echo $ip $'\t' $(whois $ip | grep -i "^$FIELD" | uniq)
+  fi
 done


### PR DESCRIPTION
If var $FIELD value is setted "organization", try to looking for Organization name from WHOIS response not only in Organization field. Because, no every response contains Organization field. In such way, try to find "OrgName|^org-name|^role|^person" in response.